### PR TITLE
fix php deprecated warning when passing null as subject in preg_match()

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -1450,13 +1450,17 @@ class Mobile_Detect
      * the User-Agent string.
      *
      * @param $regex
-     * @param  string $userAgent
+     * @param string $userAgent
      * @return bool
      *
      * @todo: search in the HTTP headers too.
      */
     public function match($regex, $userAgent = null)
     {
+        if (!\is_string($userAgent) && !\is_string($this->userAgent)) {
+            return false;
+        }
+
         $match = (bool) preg_match(sprintf('#%s#is', $regex), (false === empty($userAgent) ? $userAgent : $this->userAgent), $matches);
         // If positive match is found, store the results for debug.
         if ($match) {


### PR DESCRIPTION
fix #876